### PR TITLE
清理build cache，解决切换分支时，出现编译错误的情况

### DIFF
--- a/autoregister/src/main/groovy/com/billy/android/register/RegisterTransform.groovy
+++ b/autoregister/src/main/groovy/com/billy/android/register/RegisterTransform.groovy
@@ -47,6 +47,10 @@ class RegisterTransform extends Transform {
                    , TransformOutputProvider outputProvider
                    , boolean isIncremental) throws IOException, TransformException, InterruptedException {
         project.logger.warn("start auto-register transform...")
+        // clean build cache
+        if (!isIncremental) {
+            outputProvider.deleteAll()
+        }
         config.reset()
         project.logger.warn(config.toString())
         CodeScanProcessor scanProcessor = new CodeScanProcessor(config.list)


### PR DESCRIPTION
在没有进行增量编译时，应每次清理上次输出的Jar，以免出现mergeJarException